### PR TITLE
restrict s3 actions to cur s3 object

### DIFF
--- a/cloudformation/StaxCurSetup.yml
+++ b/cloudformation/StaxCurSetup.yml
@@ -16,6 +16,11 @@ Parameters:
     Type: String
     AllowedPattern: "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$"
 
+  CurBucket:
+    Type: String
+    Description: "The CUR S3 bucket name for Stax Billing"
+    AllowedPattern: "^arn:aws:s3:([^:\\n]*):([^:\\n]*):([^:\\/\\n]*)$"
+
 Resources:
   StaxCurSetupRole:
     Type: AWS::IAM::Role
@@ -33,6 +38,16 @@ Resources:
             Condition:
               StringEquals:
                 "sts:ExternalId": !Ref DistributorId
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+      Policies:
+        - PolicyName: "stax-cur-import"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:*"
+                Resource:
+                  - !Ref CurBucket
+                  - !Sub "${CurBucket}/*"
+
 

--- a/cloudformation/StaxCurSetup.yml
+++ b/cloudformation/StaxCurSetup.yml
@@ -19,7 +19,6 @@ Parameters:
   CurBucket:
     Type: String
     Description: "The CUR S3 bucket name for Stax Billing"
-    AllowedPattern: "^arn:aws:s3:([^:\\n]*):([^:\\n]*):([^:\\/\\n]*)$"
 
 Resources:
   StaxCurSetupRole:
@@ -47,7 +46,5 @@ Resources:
                 Action:
                   - "s3:*"
                 Resource:
-                  - !Ref CurBucket
-                  - !Sub "${CurBucket}/*"
-
-
+                  - !Sub "arn:aws:s3:::${CurBucket}"
+                  - !Sub "arn:aws:s3:::${CurBucket}/*"


### PR DESCRIPTION
Remove the S3 full access policy for all objects and restrict S3 actions to the `CurArn` parameter.